### PR TITLE
Fix comment typos

### DIFF
--- a/src/app/app.service.ts
+++ b/src/app/app.service.ts
@@ -49,7 +49,7 @@ export class AppService {
   }
 
   ////////////////////////////////////////////////////
-  //METHODES
+  //METHODS
   onUpdateTitle(title: string) {
     this.title.emit(title);
   }

--- a/src/app/main/sidebar/sidebar.component.ts
+++ b/src/app/main/sidebar/sidebar.component.ts
@@ -34,7 +34,7 @@ export class SidebarComponent implements OnInit {
   }
 
   ////////////////////////////////////////////////////
-  //METHODES
+  //METHODS
   onClick(name) {
     this.appService.onUpdateTitle(name);
     this.appService.onGetSubMenuItem(name);

--- a/src/app/main/sidebar/subsidebar/subsidebar.component.ts
+++ b/src/app/main/sidebar/subsidebar/subsidebar.component.ts
@@ -49,7 +49,7 @@ export class SubsidebarComponent implements OnInit, OnDestroy {
     this.subscription.unsubscribe();
   }
   ////////////////////////////////////////////////////
-  //METHODES
+  //METHODS
   onClose() {
     this.appService.onCloseSubSidebar();
   }


### PR DESCRIPTION
## Summary
- correct `//METHODES` comment typo in services and sidebar components

## Testing
- `npm test` *(fails: ng not found)*
- `npm install` *(fails: node-sass build requires Python 2)*

------
https://chatgpt.com/codex/tasks/task_e_688bc7c2175083248efbdbbd15b06a1e