### PR TITLE
Update app component tests

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,10 +1,14 @@
 import { TestBed, async } from '@angular/core/testing';
 import { AppComponent } from './app.component';
+import { NavComponent } from './nav/nav.component';
+import { MainComponent } from './main/main.component';
 describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
-        AppComponent
+        AppComponent,
+        NavComponent,
+        MainComponent
       ],
     }).compileComponents();
   }));
@@ -13,15 +17,11 @@ describe('AppComponent', () => {
     const app = fixture.debugElement.componentInstance;
     expect(app).toBeTruthy();
   }));
-  it(`should have as title 'app'`, async(() => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.debugElement.componentInstance;
-    expect(app.title).toEqual('app');
-  }));
-  it('should render title in a h1 tag', async(() => {
+  it('should render navigation and main components', async(() => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector('h1').textContent).toContain('Welcome to app!');
+    expect(compiled.querySelector('app-nav')).toBeTruthy();
+    expect(compiled.querySelector('app-main')).toBeTruthy();
   }));
 });


### PR DESCRIPTION
## Summary
- ensure test module declares `NavComponent` and `MainComponent`
- replace obsolete title checks with presence checks for navigation and main elements

## Testing
- `npm test -- --single-run --browsers=ChromeHeadless` *(fails: Cannot start ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_688bc7c2bfe48324bef147ade39d6746