### PR TITLE
Add English tennis booking architecture overview

### DIFF
--- a/tennis-booking-architecture-en.md
+++ b/tennis-booking-architecture-en.md
@@ -1,0 +1,110 @@
+## Tennis Court Booking Application Kick-off Guide
+
+### 1. High-Level Architecture (Macro-Services Architecture)
+
+- **Gateway / API Gateway**
+  - Entry point for all user requests.
+  - Applies rate limiting, initial authentication, and routes to downstream services.
+
+- **Identity & Access Service**
+  - Sign-up, login, role management (player, club manager).
+  - Supports OAuth/OpenID Connect for integrations with external services.
+
+- **Court Management Service**
+  - Manages courts, available slots, and the calendar.
+  - Domain model: Court, CourtAvailability, MaintenanceWindow.
+  - Domain rules such as "court preparation time after each booking."
+
+- **Booking Service**
+  - Handles booking, cancellation, and waitlist management.
+  - Domain model: Booking, ReservationPolicy, PaymentStatus.
+  - Domain rules such as weekly booking limits per user.
+
+- **Pricing & Payment Service**
+  - Calculates costs, discounts, and processes payments.
+  - Connects to external payment providers.
+
+- **Notification Service**
+  - Sends notifications via email/SMS/push.
+  - Event-driven pattern to react to new or canceled bookings.
+
+- **Analytics & Reporting Service**
+  - Collects event data (Event Sourcing or CDC).
+  - Provides management dashboards.
+
+- **Admin Panel (Angular SPA)**
+  - Manages users, courts, and metrics.
+  - Communicates through the API Gateway and a dedicated Backend for Frontend (BFF).
+
+- **Player Web App (Angular)**
+  - Allows booking, viewing history, and payments.
+
+- **Shared Kernel / Platform Services**
+  - Shared library for DTOs, events, and contracts.
+  - Supporting services such as logging, monitoring, configuration, and service discovery.
+
+### 2. Domain-Driven Design (DDD) in the Backend
+
+- **Bounded Contexts**: Identity, Court Management, Booking, Billing, Notifications.
+- **Context Map**: Relationships (Customer/Supplier, Conformist, Anti-corruption Layer).
+- **Aggregates & Entities**: Booking as the aggregate root with value objects like TimeSlot.
+
+### 3. Recommended Tools and Technologies
+
+- **Backend**: NestJS or Spring Boot (both fit microservice and hexagonal architecture with DDD).
+- **Message Broker**: Kafka or RabbitMQ for event-driven interactions between services.
+- **Database per Service**: e.g., PostgreSQL for Booking and Court; Redis for caching.
+- **Infrastructure as Code**: Terraform or Pulumi to manage environments.
+- **CI/CD**: GitHub Actions or GitLab CI.
+- **Observability**: OpenTelemetry + Prometheus/Grafana.
+
+### 4. Suggested Visual Blueprint (Charts)
+
+Use tools like **draw.io (diagrams.net)**, **Miro**, or **Lucidchart** to prepare diagrams:
+
+1. **Context Diagram**: Shows services and high-level interactions (Gateway ↔ services, payment gateway, SMS system).
+2. **Container Diagram (C4 Model Level 2)**: Breaks down services, databases, message broker, and frontends.
+3. **Component Diagram for each Bounded Context**: Internal components of the Booking Service (Application Layer, Domain Layer, Infrastructure Layer).
+4. **Sequence Diagram for the Booking Scenario**: From user sign-in to notification delivery.
+
+### 5. Resources and Templates
+
+- **Awesome Microservices Templates**
+  - [Microservices.io](https://microservices.io/) for architecture patterns.
+  - [Awesome Microservices (GitHub)](https://github.com/mfornos/awesome-microservices) for project lists and frameworks.
+
+- **DDD Resources**
+  - [Awesome Domain-Driven Design](https://github.com/heynickc/awesome-ddd).
+  - Sample projects for DDD with NestJS: search for "nestjs ddd microservices boilerplate."
+
+- **Angular + Nx Monorepo**
+  - [Nx Workspace](https://nx.dev/) for creating a monorepo with Angular and NestJS.
+  - Template [nrwl/nx-examples](https://github.com/nrwl/nx-examples).
+
+- **Hexagonal Architecture Samples**
+  - [albertllousas/hexagonal-architecture-example](https://github.com/albertllousas/hexagonal-architecture-example).
+  - For Java/Spring: [melardev/hexagonal-architecture-springboot](https://github.com/melardev/hexagonal-architecture-springboot).
+
+### 6. Suggested Onboarding Workflow
+
+1. **Define the Vision and Use Cases**: Key scenarios for booking, court management, and payments.
+2. **Domain Modeling with Event Storming**: Identify aggregates and domain events.
+3. **Design the Context Map**: Establish service boundaries.
+4. **Create an Nx Monorepo** (Angular + NestJS) or choose a multi-repo approach.
+5. **Implement Gateway and Identity** as the foundation.
+6. **Build Booking and Court Services** with domain-level tests.
+7. **Develop the Angular Frontend** with a BFF or GraphQL in mind.
+8. **Consider DevOps and Observability** from day one (pipelines, monitoring).
+
+### 7. Visual Design Tools
+
+- **diagrams.net** (free and simple)
+- **Miro** (collaborative)
+- **Figma** (UI/UX and wireframes)
+- **Structurizr** (C4 model modeling)
+
+You can start with a base diagram in one of these tools and gradually add more details.
+
+---
+
+If you need a more detailed chart or diagram examples, I can provide ASCII templates or more specific guidance for your chosen tool.


### PR DESCRIPTION
## Summary
- add an English-language guide outlining the tennis court booking application's architecture and supporting resources

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_6902017572c08324953b3a8d2bcda3c4