### PR TITLE
Add interactive HTML architecture view

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,630 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tennis Booking Platform Architecture</title>
+  <style>
+    :root {
+      --bg: #0f172a;
+      --panel: #1e293b;
+      --accent: #38bdf8;
+      --text: #e2e8f0;
+      --muted: #94a3b8;
+      --card-border: #3b82f6;
+      --highlight: rgba(56, 189, 248, 0.2);
+      font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      background: linear-gradient(160deg, #0f172a 0%, #1e293b 100%);
+      color: var(--text);
+    }
+
+    header {
+      padding: 2.5rem 1.25rem 1.5rem;
+      text-align: center;
+    }
+
+    header h1 {
+      margin: 0;
+      font-size: clamp(2.2rem, 3vw, 3.4rem);
+      letter-spacing: 0.08em;
+    }
+
+    header p {
+      margin: 0.75rem auto 0;
+      max-width: 60ch;
+      color: var(--muted);
+      line-height: 1.6;
+    }
+
+    main {
+      padding: 0 1.25rem 3rem;
+      display: grid;
+      gap: 1.5rem;
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+
+    .legend {
+      background: rgba(15, 23, 42, 0.7);
+      backdrop-filter: blur(10px);
+      border-radius: 16px;
+      border: 1px solid rgba(148, 163, 184, 0.3);
+      padding: 1.25rem 1.5rem;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      justify-content: center;
+    }
+
+    .legend span {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.4rem 0.9rem;
+      border-radius: 999px;
+      background: rgba(59, 130, 246, 0.15);
+      border: 1px solid rgba(59, 130, 246, 0.35);
+      font-size: 0.9rem;
+    }
+
+    .board {
+      display: grid;
+      gap: 1.5rem;
+    }
+
+    .row {
+      display: grid;
+      gap: 1.5rem;
+    }
+
+    @media (min-width: 920px) {
+      .row.multi {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    .card {
+      position: relative;
+      background: rgba(15, 23, 42, 0.85);
+      border: 1px solid rgba(56, 189, 248, 0.3);
+      border-radius: 18px;
+      padding: 1.4rem 1.4rem 1.75rem;
+      transition: transform 200ms ease, box-shadow 200ms ease, border-color 200ms ease;
+      overflow: hidden;
+    }
+
+    .card:hover {
+      transform: translateY(-6px);
+      border-color: rgba(56, 189, 248, 0.75);
+      box-shadow: 0 18px 35px rgba(56, 189, 248, 0.15);
+    }
+
+    .card h2 {
+      margin-top: 0;
+      font-size: 1.4rem;
+    }
+
+    .tag {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.45rem;
+      padding: 0.2rem 0.75rem;
+      border-radius: 999px;
+      background: rgba(56, 189, 248, 0.15);
+      color: var(--accent);
+      border: 1px solid rgba(56, 189, 248, 0.4);
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      margin-bottom: 0.8rem;
+    }
+
+    .card ul {
+      margin: 0.5rem 0 0;
+      padding-left: 1.1rem;
+      line-height: 1.6;
+      color: var(--muted);
+    }
+
+    .card ul li+li {
+      margin-top: 0.4rem;
+    }
+
+    .detail-button {
+      margin-top: 1rem;
+      border: none;
+      background: rgba(56, 189, 248, 0.18);
+      color: var(--accent);
+      padding: 0.55rem 1rem;
+      border-radius: 10px;
+      cursor: pointer;
+      font-size: 0.9rem;
+      transition: background 200ms ease, transform 200ms ease;
+    }
+
+    .detail-button:hover {
+      background: rgba(56, 189, 248, 0.25);
+      transform: translateY(-2px);
+    }
+
+    details {
+      margin-top: 0.9rem;
+      padding: 0.85rem;
+      border-radius: 12px;
+      background: rgba(148, 163, 184, 0.1);
+      border: 1px solid rgba(148, 163, 184, 0.25);
+    }
+
+    details[open] {
+      background: rgba(56, 189, 248, 0.15);
+      border-color: rgba(56, 189, 248, 0.4);
+    }
+
+    summary {
+      cursor: pointer;
+      font-weight: 600;
+    }
+
+    .connections {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 1rem;
+    }
+
+    .connection {
+      padding: 0.85rem 1rem;
+      border-radius: 12px;
+      background: rgba(30, 41, 59, 0.8);
+      border: 1px dashed rgba(56, 189, 248, 0.3);
+      font-size: 0.95rem;
+      color: var(--muted);
+    }
+
+    footer {
+      text-align: center;
+      color: var(--muted);
+      padding: 1.5rem;
+      font-size: 0.85rem;
+    }
+
+    .filter-toolbar {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      justify-content: center;
+      padding: 0.75rem 0;
+    }
+
+    .filter-toolbar button {
+      border: 1px solid rgba(148, 163, 184, 0.4);
+      background: rgba(15, 23, 42, 0.6);
+      color: var(--muted);
+      padding: 0.45rem 1rem;
+      border-radius: 999px;
+      cursor: pointer;
+      transition: background 200ms ease, border-color 200ms ease, color 200ms ease;
+      font-size: 0.85rem;
+    }
+
+    .filter-toolbar button.active,
+    .filter-toolbar button:hover {
+      color: var(--text);
+      border-color: rgba(56, 189, 248, 0.5);
+      background: rgba(56, 189, 248, 0.15);
+    }
+
+    .card[data-category="frontend"] {
+      border-color: rgba(16, 185, 129, 0.3);
+    }
+
+    .card[data-category="roles"] {
+      border-color: rgba(249, 115, 22, 0.35);
+    }
+
+    .card[data-category="platform"] {
+      border-color: rgba(192, 38, 211, 0.3);
+    }
+
+    .card.hidden {
+      display: none;
+    }
+
+    .row-title {
+      font-size: 1.1rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: rgba(148, 163, 184, 0.8);
+    }
+  </style>
+</head>
+
+<body>
+  <header>
+    <h1>Tennis Booking Platform – Provider-Service Macro Architecture</h1>
+    <p>
+      Explore the macro-services layout, provider/service domain language, and supporting platform components that power
+      the tennis court booking experience. Use the filters to focus on specific layers or domain roles and expand cards
+      for additional context.
+    </p>
+  </header>
+
+  <main>
+    <section class="legend">
+      <span>🧭 Gateway</span>
+      <span>🧑‍💻 Frontend Apps</span>
+      <span>🏷️ Domain Roles</span>
+      <span>🧱 Core Services</span>
+      <span>📡 Messaging &amp; Integrations</span>
+      <span>🛡️ Platform &amp; Shared Kernel</span>
+    </section>
+
+    <div class="filter-toolbar">
+      <button class="active" data-filter="all">Show All</button>
+      <button data-filter="roles">Domain Roles</button>
+      <button data-filter="frontend">Frontend</button>
+      <button data-filter="core">Core Services</button>
+      <button data-filter="platform">Platform</button>
+    </div>
+
+    <section class="board">
+      <div class="row">
+        <div class="row-title">Domain Roles</div>
+        <div class="row multi">
+          <article class="card" data-category="roles">
+            <span class="tag">Domain Role</span>
+            <h2>Provider</h2>
+            <ul>
+              <li>Tennis club or venue that supplies services (courts, coaching).</li>
+              <li>Owns catalog, pricing, and maintenance policies.</li>
+              <li>Works closely with Provider &amp; Court Management and Analytics.</li>
+            </ul>
+            <details>
+              <summary>Key Responsibilities</summary>
+              <ul>
+                <li>Publish availability for each service.</li>
+                <li>Respond to booking notifications and adjustments.</li>
+                <li>Maintain facility readiness and quality.</li>
+              </ul>
+            </details>
+          </article>
+
+          <article class="card" data-category="roles">
+            <span class="tag">Domain Role</span>
+            <h2>Service</h2>
+            <ul>
+              <li>Bookable asset owned by a provider (court, lesson, equipment).</li>
+              <li>Contains capacity rules, pricing models, and prep buffers.</li>
+              <li>Managed through Provider &amp; Court Management, consumed by Booking.</li>
+            </ul>
+            <details>
+              <summary>Domain Notes</summary>
+              <ul>
+                <li>Value objects define schedules and time slots.</li>
+                <li>Policies enforce downtime, maintenance, and overbooking rules.</li>
+                <li>Events propagate to Analytics and Notifications.</li>
+              </ul>
+            </details>
+          </article>
+
+          <article class="card" data-category="roles">
+            <span class="tag">Domain Role</span>
+            <h2>Customer</h2>
+            <ul>
+              <li>Player who discovers providers and books services.</li>
+              <li>Interacts through the Customer Web App and receives notifications.</li>
+              <li>Subject to booking policies, payments, and loyalty programs.</li>
+            </ul>
+            <details>
+              <summary>Experience Touchpoints</summary>
+              <ul>
+                <li>Identity &amp; Access for authentication.</li>
+                <li>Booking and Payment flows for reservations.</li>
+                <li>Notification service for reminders and updates.</li>
+              </ul>
+            </details>
+          </article>
+
+          <article class="card" data-category="roles">
+            <span class="tag">Domain Role</span>
+            <h2>Admin</h2>
+            <ul>
+              <li>Platform operator managing providers, services, and compliance.</li>
+              <li>Uses the Admin Panel for oversight and configuration.</li>
+              <li>Coordinates incident response and rollout plans.</li>
+            </ul>
+            <details>
+              <summary>Key Capabilities</summary>
+              <ul>
+                <li>Approve provider onboarding and catalog changes.</li>
+                <li>Monitor analytics and enforce policy adherence.</li>
+                <li>Manage infrastructure transitions (Compose → Kubernetes).</li>
+              </ul>
+            </details>
+          </article>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="row-title">Experience Layer</div>
+        <div class="row multi">
+          <article class="card" data-category="frontend">
+            <span class="tag">Frontend</span>
+            <h2>Customer Web App (Angular)</h2>
+            <ul>
+              <li>Discover providers, book services, manage reservations, and view history.</li>
+              <li>Integrates with BFF layer for optimized APIs.</li>
+              <li>Provides payment, loyalty, and notification workflows.</li>
+            </ul>
+            <details>
+              <summary>Key UI concerns</summary>
+              <ul>
+                <li>Calendar components for slot selection.</li>
+                <li>Responsive layout for mobile booking.</li>
+                <li>Real-time updates via WebSocket or SSE.</li>
+              </ul>
+            </details>
+          </article>
+
+          <article class="card" data-category="frontend">
+            <span class="tag">Frontend</span>
+            <h2>Admin Panel (Angular)</h2>
+            <ul>
+              <li>Manage providers, services, schedules, pricing, and promotions.</li>
+              <li>Provides dashboards for utilization analytics.</li>
+              <li>Role-based access across providers, their staff, and platform admins.</li>
+            </ul>
+            <details>
+              <summary>Key UI concerns</summary>
+              <ul>
+                <li>Rich data tables with filtering and export.</li>
+                <li>Integrations with analytics microservice.</li>
+                <li>Audit trails and activity feeds.</li>
+              </ul>
+            </details>
+          </article>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="row-title">Edge &amp; Orchestration</div>
+        <div class="row multi">
+          <article class="card" data-category="core">
+            <span class="tag">Gateway</span>
+            <h2>API Gateway / BFF</h2>
+            <ul>
+              <li>Routing, rate-limiting, and API composition.</li>
+              <li>Authentication handoff to Identity service.</li>
+              <li>GraphQL/REST aggregation for frontends.</li>
+            </ul>
+          </article>
+
+          <article class="card" data-category="core">
+            <span class="tag">Core Service</span>
+            <h2>Identity &amp; Access</h2>
+            <ul>
+              <li>Account provisioning, SSO, and role management.</li>
+              <li>Issues tokens via OAuth/OIDC.</li>
+              <li>Supports customer, provider, and admin personas with scoped roles.</li>
+            </ul>
+            <details>
+              <summary>Domain Notes</summary>
+              <ul>
+                <li>Bounded Context: Identity.</li>
+                <li>Aggregates: User, Role, Session.</li>
+                <li>Integrates with audit logging for compliance.</li>
+              </ul>
+            </details>
+          </article>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="row-title">Core Booking Domain</div>
+        <div class="row multi">
+          <article class="card" data-category="core">
+            <span class="tag">Core Service</span>
+            <h2>Provider &amp; Court Management</h2>
+            <ul>
+              <li>Handles provider profiles, service inventory, availability, and maintenance windows.</li>
+              <li>Tracks provider policies, preparation buffers, and blackout periods per service.</li>
+              <li>Exposes events for scheduling updates.</li>
+            </ul>
+            <details>
+              <summary>DDD Focus</summary>
+              <ul>
+                <li>Bounded Context: Provider &amp; Court Management.</li>
+                <li>Aggregates: Provider, ProviderService, TimeSlot, MaintenanceWindow.</li>
+                <li>Policies for maintenance and setup time.</li>
+              </ul>
+            </details>
+          </article>
+
+          <article class="card" data-category="core">
+            <span class="tag">Core Service</span>
+            <h2>Booking Service</h2>
+            <ul>
+              <li>Validates booking rules and conflicts between customers and provider services.</li>
+              <li>Supports waitlists, cancellations, reassignments, and provider overrides.</li>
+              <li>Publishes provider/customer domain events for notifications and analytics.</li>
+            </ul>
+            <details>
+              <summary>DDD Focus</summary>
+              <ul>
+                <li>Bounded Context: Booking.</li>
+                <li>Aggregates: Booking, ReservationPolicy, ProviderServiceRef, TimeSlot.</li>
+                <li>Value Objects tie customer demand, provider capacity, availability, and payments.</li>
+              </ul>
+            </details>
+          </article>
+
+          <article class="card" data-category="core">
+            <span class="tag">Core Service</span>
+            <h2>Pricing &amp; Payment</h2>
+            <ul>
+              <li>Calculates provider-specific pricing, discount models, and payout schedules.</li>
+              <li>Manages payment intents, settlement flows, and third-party gateways.</li>
+              <li>Tracks settlement and invoice state.</li>
+            </ul>
+            <details>
+              <summary>Integrations</summary>
+              <ul>
+                <li>External payment processors (Stripe, Adyen).</li>
+                <li>Ledger or accounting systems.</li>
+                <li>Fraud detection services.</li>
+              </ul>
+            </details>
+          </article>
+
+          <article class="card" data-category="core">
+            <span class="tag">Core Service</span>
+            <h2>Notification Service</h2>
+            <ul>
+              <li>Subscribes to booking and payment events.</li>
+              <li>Sends provider and customer email, SMS, and push notifications.</li>
+              <li>Template and channel management.</li>
+            </ul>
+            <details>
+              <summary>Channels</summary>
+              <ul>
+                <li>SMS gateway integrations.</li>
+                <li>Email providers (SendGrid, SES).</li>
+                <li>Mobile push via Firebase/APNs.</li>
+              </ul>
+            </details>
+          </article>
+
+          <article class="card" data-category="core">
+            <span class="tag">Core Service</span>
+            <h2>Analytics &amp; Reporting</h2>
+            <ul>
+              <li>Consumes domain events for utilization metrics.</li>
+              <li>Provides dashboards and exports for admins and providers.</li>
+              <li>Supports experimentation and cohort analysis.</li>
+            </ul>
+            <details>
+              <summary>Data Strategy</summary>
+              <ul>
+                <li>Event sourcing or CDC pipelines.</li>
+                <li>Aggregated data warehouse (BigQuery, Snowflake).</li>
+                <li>BI tooling integration.</li>
+              </ul>
+            </details>
+          </article>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="row-title">Platform &amp; Shared Services</div>
+        <div class="row multi">
+          <article class="card" data-category="platform">
+            <span class="tag">Platform</span>
+            <h2>Event Streaming &amp; Messaging</h2>
+            <ul>
+              <li>Kafka or RabbitMQ for asynchronous workflows.</li>
+              <li>Domain events propagate across contexts.</li>
+              <li>Supports CQRS read models.</li>
+            </ul>
+          </article>
+
+          <article class="card" data-category="platform">
+            <span class="tag">Platform</span>
+            <h2>Shared Kernel &amp; Libraries</h2>
+            <ul>
+              <li>Common DTOs, contracts, and provider/service event schemas.</li>
+              <li>Cross-cutting concerns (logging, tracing).</li>
+              <li>Nx or monorepo tooling for reuse.</li>
+            </ul>
+          </article>
+
+          <article class="card" data-category="platform">
+            <span class="tag">Platform</span>
+            <h2>Observability Stack</h2>
+            <ul>
+              <li>OpenTelemetry instrumentation.</li>
+              <li>Prometheus/Grafana dashboards.</li>
+              <li>Centralized log aggregation.</li>
+            </ul>
+          </article>
+
+          <article class="card" data-category="platform">
+            <span class="tag">Platform</span>
+            <h2>DevOps &amp; Infrastructure</h2>
+            <ul>
+              <li>Infrastructure as Code (Terraform/Pulumi).</li>
+              <li>CI/CD pipelines with GitHub Actions.</li>
+              <li>Lifecycle plan: launch with Docker Compose, scale to Kubernetes as demand grows.</li>
+              <li>Service discovery and configuration.</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="row-title">Context Relationships</div>
+        <div class="card" data-category="core">
+          <span class="tag">Context Map</span>
+          <div class="connections">
+            <div class="connection">
+              <strong>Booking ↔ Provider &amp; Court Management</strong><br />
+              Supplier/Consumer relationship translating provider service availability into booking offers.
+            </div>
+            <div class="connection">
+              <strong>Booking ↔ Pricing &amp; Payment</strong><br />
+              Conformist integration for provider-specific price validation, payments, and settlements.
+            </div>
+            <div class="connection">
+              <strong>Booking ↔ Notification</strong><br />
+              Event-driven updates informing providers and customers of confirmations and waitlists.
+            </div>
+            <div class="connection">
+              <strong>Identity ↔ All Services</strong><br />
+              Token validation and role enforcement for providers, services, customers, and admins.
+            </div>
+            <div class="connection">
+              <strong>Analytics ↔ Messaging</strong><br />
+              Stream processors build provider/service utilization insights and dashboards.
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    Crafted as an interactive overview of the provider–service tennis booking architecture. Hover over cards or expand
+    sections to explore details.
+  </footer>
+
+  <script>
+    const toolbarButtons = document.querySelectorAll(".filter-toolbar button");
+    const cards = document.querySelectorAll(".card");
+
+    toolbarButtons.forEach((button) => {
+      button.addEventListener("click", () => {
+        toolbarButtons.forEach((btn) => btn.classList.remove("active"));
+        button.classList.add("active");
+
+        const filter = button.dataset.filter;
+
+        cards.forEach((card) => {
+          card.classList.remove("hidden");
+          if (filter !== "all" && card.dataset.category !== filter) {
+            card.classList.add("hidden");
+          }
+        });
+      });
+    });
+  </script>
+</body>
+
+</html>

--- a/tennis-booking-architecture-en.md
+++ b/tennis-booking-architecture-en.md
@@ -3,40 +3,49 @@
 ### 1. High-Level Architecture (Macro-Services Architecture)
 
 - **Gateway / API Gateway**
+
   - Entry point for all user requests.
   - Applies rate limiting, initial authentication, and routes to downstream services.
 
 - **Identity & Access Service**
+
   - Sign-up, login, role management (player, club manager).
   - Supports OAuth/OpenID Connect for integrations with external services.
 
 - **Court Management Service**
+
   - Manages courts, available slots, and the calendar.
   - Domain model: Court, CourtAvailability, MaintenanceWindow.
   - Domain rules such as "court preparation time after each booking."
 
 - **Booking Service**
+
   - Handles booking, cancellation, and waitlist management.
   - Domain model: Booking, ReservationPolicy, PaymentStatus.
   - Domain rules such as weekly booking limits per user.
 
 - **Pricing & Payment Service**
+
   - Calculates costs, discounts, and processes payments.
   - Connects to external payment providers.
 
 - **Notification Service**
+
   - Sends notifications via email/SMS/push.
   - Event-driven pattern to react to new or canceled bookings.
 
 - **Analytics & Reporting Service**
+
   - Collects event data (Event Sourcing or CDC).
   - Provides management dashboards.
 
 - **Admin Panel (Angular SPA)**
+
   - Manages users, courts, and metrics.
   - Communicates through the API Gateway and a dedicated Backend for Frontend (BFF).
 
 - **Player Web App (Angular)**
+
   - Allows booking, viewing history, and payments.
 
 - **Shared Kernel / Platform Services**
@@ -70,14 +79,17 @@ Use tools like **draw.io (diagrams.net)**, **Miro**, or **Lucidchart** to prepar
 ### 5. Resources and Templates
 
 - **Awesome Microservices Templates**
+
   - [Microservices.io](https://microservices.io/) for architecture patterns.
   - [Awesome Microservices (GitHub)](https://github.com/mfornos/awesome-microservices) for project lists and frameworks.
 
 - **DDD Resources**
+
   - [Awesome Domain-Driven Design](https://github.com/heynickc/awesome-ddd).
   - Sample projects for DDD with NestJS: search for "nestjs ddd microservices boilerplate."
 
 - **Angular + Nx Monorepo**
+
   - [Nx Workspace](https://nx.dev/) for creating a monorepo with Angular and NestJS.
   - Template [nrwl/nx-examples](https://github.com/nrwl/nx-examples).
 
@@ -107,4 +119,125 @@ You can start with a base diagram in one of these tools and gradually add more d
 
 ---
 
-If you need a more detailed chart or diagram examples, I can provide ASCII templates or more specific guidance for your chosen tool.
+# If you need a more detailed chart or diagram examples, I can provide ASCII templates or more specific guidance for your chosen tool.
+
+# Tennis Booking Platform Architecture Overview
+
+This guide captures the macro-service architecture, DDD considerations, and onboarding workflow for the tennis court booking application. A colourful interactive HTML diagram is also available for quick exploration of the layout.
+
+- [Open the interactive architecture board](./architecture-diagram.html)
+
+## 1. Macro-Services Architecture
+
+- **Gateway / API Gateway**
+
+  - Entry point for all client requests.
+  - Provides rate limiting, authentication hand-off, and routing to downstream services.
+
+- **Identity & Access Service**
+
+  - Handles sign-up, login, and role management (player, club administrator).
+  - Supports OAuth/OpenID Connect for external integrations.
+
+- **Court Management Service**
+
+  - Maintains court inventory, availability windows, and maintenance schedules.
+  - Implements domain rules such as “buffer time between reservations”.
+
+- **Booking Service**
+
+  - Processes bookings, cancellations, and waitlists.
+  - Implements policies for weekly booking limits per user.
+
+- **Pricing & Payment Service**
+
+  - Calculates pricing, discounts, and handles payment workflows.
+  - Integrates with third-party payment gateways.
+
+- **Notification Service**
+
+  - Sends email/SMS/push notifications for booking updates.
+  - Event-driven reactions to booking or cancellation events.
+
+- **Analytics & Reporting Service**
+
+  - Collects event data (event sourcing or CDC) for insights.
+  - Powers administrative dashboards.
+
+- **Admin Panel (Angular SPA)**
+
+  - Administration portal for users, courts, and reports.
+  - Communicates via an API Gateway and a web-focused BFF.
+
+- **Player Web App (Angular)**
+
+  - Allows players to browse availability, reserve courts, and pay.
+
+- **Shared Kernel / Platform Services**
+  - Shared library of DTOs, events, and service contracts.
+  - Supporting services: logging, monitoring, configuration, service discovery.
+
+## 2. Domain-Driven Design (DDD)
+
+- **Bounded Contexts**: Identity, Court Management, Booking, Billing, Notifications.
+- **Context Map**: Relationships (Customer/Supplier, Conformist, Anti-corruption Layer).
+- **Aggregates & Entities**: For example, Booking as an aggregate root with value objects such as TimeSlot.
+
+## 3. Suggested Tooling
+
+- **Backend**: NestJS or Spring Boot for microservice-friendly DDD and hexagonal architecture.
+- **Message Broker**: Kafka or RabbitMQ for event-driven communication.
+- **Database per Service**: PostgreSQL for Booking/Court, Redis for caching.
+- **Infrastructure as Code**: Terraform or Pulumi to manage environments.
+- **CI/CD**: GitHub Actions or GitLab CI.
+- **Observability**: OpenTelemetry with Prometheus/Grafana.
+
+## 4. Visual Documentation Recommendations
+
+Use visual tools such as **diagrams.net**, **Miro**, **Lucidchart**, or **Structurizr** to maintain these artifacts:
+
+1. **Context Diagram**: Shows top-level services and interactions (Gateway ↔ services, payment provider, SMS system).
+2. **Container Diagram (C4 Level 2)**: Breaks down services, data stores, message brokers, and front-ends.
+3. **Component Diagram per Bounded Context**: e.g., Booking Service’s Application/Domain/Infrastructure layers.
+4. **Sequence Diagram for Booking Flow**: From user login to payment confirmation and notification.
+
+## 5. Starter Templates & Resources
+
+- **Microservice Patterns**
+
+  - [microservices.io](https://microservices.io/)
+  - [Awesome Microservices](https://github.com/mfornos/awesome-microservices)
+
+- **DDD Resources**
+
+  - [Awesome Domain-Driven Design](https://github.com/heynickc/awesome-ddd)
+  - Sample projects (search for “nestjs ddd microservices boilerplate”).
+
+- **Angular + Nx Monorepo**
+
+  - [Nx Workspace](https://nx.dev/)
+  - [nrwl/nx-examples](https://github.com/nrwl/nx-examples)
+
+- **Hexagonal Architecture Samples**
+  - [albertllousas/hexagonal-architecture-example](https://github.com/albertllousas/hexagonal-architecture-example)
+  - [melardev/hexagonal-architecture-springboot](https://github.com/melardev/hexagonal-architecture-springboot)
+
+## 6. Suggested Starting Steps
+
+1. **Define Vision and Use Cases**: Booking, court management, payment, and notifications.
+2. **Model the Domain via Event Storming**: Identify aggregates, policies, and domain events.
+3. **Design the Context Map**: Clarify service boundaries and relationships.
+4. **Create an Nx Monorepo (Angular + NestJS)** or choose a polyrepo layout.
+5. **Implement Gateway and Identity** as foundational services.
+6. **Develop Booking and Court Services** with domain tests.
+7. **Build Angular Frontends** aligned with the BFF or GraphQL endpoints.
+8. **Plan DevOps & Observability** early (pipelines, monitoring, alerting).
+
+## 7. Design Tools
+
+- **diagrams.net** – free and accessible for quick diagrams.
+- **Miro** – collaborative whiteboarding for teams.
+- **Figma** – for UI/UX and wireframing.
+- **Structurizr** – for C4 model-driven documentation.
+
+Use these tools alongside the interactive HTML board to maintain a clear, evolving picture of your architecture.


### PR DESCRIPTION
## Summary
- add a colorful interactive HTML board that visualizes the tennis booking macro-architecture with filtering and expandable details
- link the existing English architecture guide to the new board for quick navigation

## Testing
- not run (documentation and static asset changes only)

------
https://chatgpt.com/codex/tasks/task_e_6902017572c08324953b3a8d2bcda3c4